### PR TITLE
Save sessions explicitly before redirect

### DIFF
--- a/lib/Passwordless/passwordless.js
+++ b/lib/Passwordless/passwordless.js
@@ -116,6 +116,15 @@ Passwordless.prototype.acceptToken = function(options) {
 			self._tokenStore.authenticate(token, uid, function(error, valid, referrer) {
 				if(valid) {
 					var success = function() {
+
+						function saveSessionAndRedirect(to) {
+							if (!req.session) return res.redirect(to);
+							req.session.save(function(err) {
+								if (err) return next(err);
+								res.redirect(to);
+							});
+						};
+
 						req[self._userProperty] = uid;
 						if(req.session) {
 							req.session.passwordless = req[self._userProperty];
@@ -125,11 +134,11 @@ Passwordless.prototype.acceptToken = function(options) {
 						}
 						if(options.enableOriginRedirect && referrer) {
 							// next() will not be called
-							return res.redirect(referrer);
+							return saveSessionAndRedirect(referrer);
 						}
 						if(options.successRedirect) {
 							// next() will not be called and enableOriginRedirect has priority
-							return res.redirect(options.successRedirect);
+							return saveSessionAndRedirect(options.successRedirect);
 						}
 						next();
 					}


### PR DESCRIPTION
Sometimes it seems that after acceptToken makes the redirect session
data is not persisted correctly. We might have hit expressjs/session#69

Persisting the session explicitely before redirect solved this at least
for me.
