### PR TITLE
Swap out base58-native dependency for bs58

### DIFF
--- a/lib/Passwordless/passwordless.js
+++ b/lib/Passwordless/passwordless.js
@@ -2,7 +2,7 @@
 
 var url = require('url');
 var crypto = require('crypto');
-var base58 = require('base58-native');
+var base58 = require('bs58');
 
 /**
  * Passwordless is a node.js module for express that allows authentication and 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Passwordless = require('./passwordless/passwordless');
+var Passwordless = require('./Passwordless/passwordless');
 
 module.exports = new Passwordless();
 module.exports.Passwordless = Passwordless;

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "supertest": "^0.12.0"
   },
   "dependencies": {
-    "base58-native": "^0.1.4"
+    "bs58": "^2.0.0"
   }
 }


### PR DESCRIPTION
Very simple change to use bs58 instead of base58-native for base58 encoding.  API used (`encode` method) remains exactly the same.

Had to change module reference in lib/index.js to use an upper case 'Password' for directory to run tests.  Would think this would be case-sensitive on other machines also.

All tests are passing after making this change.
