### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You will need:
 ```javascript
 var passwordless = require('passwordless');
 var MongoStore = require('passwordless-mongostore');
-var email   = require("emailjs");
+var email   = require('emailjs');
 ```
 
 ### 3. Setup your delivery


### PR DESCRIPTION
Minor, minor change. There was one instance where `"` was used instead of `'` for strings in a JavaScript example.