### PR TITLE
fix(tokenstoremock): fix handling of origin being null

### DIFF
--- a/test/mock/tokenstoremock.js
+++ b/test/mock/tokenstoremock.js
@@ -32,10 +32,11 @@ TokenStoreMock.prototype.authenticate = function(token, uid, callback) {
 		var found = self._findRecord(uid, token);
 
 		if(found >= 0 && self.records[found].validTill >= Date.now()) {
-			callback(null, true, self.records[found].origin);
+            var origin = self.records[found].origin;
+			callback(null, true, origin === null ? '' : origin);
 		} else {
 			callback(null, false, null);
-		}	
+		}
 	}, 0)
 };
 


### PR DESCRIPTION
When calling storeOrUpdate with origin being null, it should call
back with (null, true, **''**) (according to tests). Instead it has called back with (null, true, **null**).
This fixes it -> All tests pass now.

One little side note: When you look at the diff of this PR you see that indentation is crippled.
I was not able to fix it in a rush.
I am using the Atom Editor on Linux.
It seems that the indentation in the file is using tabs. However I've used tabs, too, but the indentation was still crippled. I don't know why.

Although this might not solve the problem, but maybe we should use an [editorconfig file](http://editorconfig.org/), so we do not have any inconsistencies regarding editor settings.

What do you think:question:
Btw: Your library is really awesome! I highly appreciate your work! :tulip: 