### PR TITLE
fix(tokenstoremock): fix handling of origin being null

### DIFF
--- a/test/mock/tokenstoremock.js
+++ b/test/mock/tokenstoremock.js
@@ -32,10 +32,11 @@ TokenStoreMock.prototype.authenticate = function(token, uid, callback) {
 		var found = self._findRecord(uid, token);
 
 		if(found >= 0 && self.records[found].validTill >= Date.now()) {
-			callback(null, true, self.records[found].origin);
+            var origin = self.records[found].origin;
+			callback(null, true, origin === null ? '' : origin);
 		} else {
 			callback(null, false, null);
-		}	
+		}
 	}, 0)
 };
 


### PR DESCRIPTION
When calling storeOrUpdate with origin being null, it should call
back with (null, true, '') (according to tests). Instead it has called back with (null, true, null).
This fixes it -> All tests pass now.